### PR TITLE
Test/cucumber fetch and save

### DIFF
--- a/src/main/java/com/xpeho/spring_boot_java_random_user/presentation/exceptions/GlobalExceptionHandler.java
+++ b/src/main/java/com/xpeho/spring_boot_java_random_user/presentation/exceptions/GlobalExceptionHandler.java
@@ -2,6 +2,7 @@ package com.xpeho.spring_boot_java_random_user.presentation.exceptions;
 
 import com.xpeho.spring_boot_java_random_user.domain.exceptions.InvalidPaginationException;
 import com.xpeho.spring_boot_java_random_user.domain.exceptions.UserNotFoundException;
+import jakarta.validation.ConstraintViolationException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
@@ -13,6 +14,16 @@ import org.springframework.web.method.annotation.MethodArgumentTypeMismatchExcep
 @RestControllerAdvice
 public class GlobalExceptionHandler {
     private static final Logger logger = LoggerFactory.getLogger(GlobalExceptionHandler.class);
+
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<ErrorResponse> handleConstraintViolationException(ConstraintViolationException ex) {
+        String message = ex.getConstraintViolations().stream()
+                .map(v -> v.getPropertyPath() + ": " + v.getMessage())
+                .findFirst()
+                .orElse(ex.getMessage());
+        logger.warn("Constraint violation: {}", message);
+        return buildErrorResponse("INVALID_PARAMETER", message, HttpStatus.BAD_REQUEST);
+    }
 
     @ExceptionHandler(InvalidPaginationException.class)
     public ResponseEntity<ErrorResponse> handleInvalidPaginationException(InvalidPaginationException ex) {

--- a/src/main/java/com/xpeho/spring_boot_java_random_user/presentation/exceptions/GlobalExceptionHandler.java
+++ b/src/main/java/com/xpeho/spring_boot_java_random_user/presentation/exceptions/GlobalExceptionHandler.java
@@ -22,7 +22,7 @@ public class GlobalExceptionHandler {
                 .findFirst()
                 .orElse(ex.getMessage());
         logger.warn("Constraint violation: {}", message);
-        return buildErrorResponse("INVALID_PARAMETER", message, HttpStatus.BAD_REQUEST);
+        return buildErrorResponse("INVALID_PAGINATION", message, HttpStatus.BAD_REQUEST);
     }
 
     @ExceptionHandler(InvalidPaginationException.class)

--- a/src/main/java/com/xpeho/spring_boot_java_random_user/presentation/handlers/UserHandler.java
+++ b/src/main/java/com/xpeho/spring_boot_java_random_user/presentation/handlers/UserHandler.java
@@ -15,6 +15,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -22,6 +23,7 @@ import java.io.IOException;
 import java.util.List;
 
 
+@Validated
 @RestController
 public class UserHandler implements UserController {
 
@@ -70,7 +72,7 @@ public class UserHandler implements UserController {
             );
             return ResponseEntity.ok(response);
         } catch (IOException e) {
-            logger.error("Error fetching random users: {}", e.getMessage(), e);
+            logger.error("Error fetching random users: {}", e.getMessage());
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
         }
     }
@@ -124,6 +126,6 @@ public class UserHandler implements UserController {
     }
 
     private void logUserNotFound(UserNotFoundException e) {
-        logger.warn(USER_NOT_FOUND_LOG, e.getMessage(), e);
+        logger.warn(USER_NOT_FOUND_LOG, e.getMessage());
     }
 }

--- a/src/main/java/com/xpeho/spring_boot_java_random_user/presentation/handlers/UserHandler.java
+++ b/src/main/java/com/xpeho/spring_boot_java_random_user/presentation/handlers/UserHandler.java
@@ -6,7 +6,6 @@ import com.xpeho.spring_boot_java_random_user.domain.entities.UserFilter;
 import com.xpeho.spring_boot_java_random_user.domain.entities.UserRequest;
 import com.xpeho.spring_boot_java_random_user.domain.enums.Gender;
 import com.xpeho.spring_boot_java_random_user.domain.enums.UserSource;
-import com.xpeho.spring_boot_java_random_user.domain.exceptions.InvalidPaginationException;
 import com.xpeho.spring_boot_java_random_user.domain.exceptions.UserNotFoundException;
 import com.xpeho.spring_boot_java_random_user.domain.usecases.*;
 import com.xpeho.spring_boot_java_random_user.presentation.controllers.UserController;
@@ -56,12 +55,6 @@ public class UserHandler implements UserController {
 
     @Override
     public ResponseEntity<UserResponseDTO> getRandomUsers(int page, int size, UserSource source) {
-        if (page < 1) {
-            throw new InvalidPaginationException("Page must be greater than or equal to 1. Requested: " + page);
-        }
-        if (size < 1 || size > 30) {
-            throw new InvalidPaginationException("Page size must be between 1 and 30. Requested: " + size);
-        }
         try {
             PaginatedUsers result = fetchAndSaveRandomUsersUseCase.execute(page, size, source);
             UserResponseDTO response = new UserResponseDTO(
@@ -72,7 +65,7 @@ public class UserHandler implements UserController {
             );
             return ResponseEntity.ok(response);
         } catch (IOException e) {
-            logger.error("Error fetching random users: {}", e.getMessage());
+            logger.error("Error fetching random users", e);
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
         }
     }
@@ -126,6 +119,6 @@ public class UserHandler implements UserController {
     }
 
     private void logUserNotFound(UserNotFoundException e) {
-        logger.warn(USER_NOT_FOUND_LOG, e.getMessage());
+        logger.warn(USER_NOT_FOUND_LOG, e);
     }
 }

--- a/src/test/java/com/xpeho/spring_boot_java_random_user/presentation/UserHandlerTest.java
+++ b/src/test/java/com/xpeho/spring_boot_java_random_user/presentation/UserHandlerTest.java
@@ -6,7 +6,6 @@ import com.xpeho.spring_boot_java_random_user.domain.entities.UserFilter;
 import com.xpeho.spring_boot_java_random_user.domain.entities.UserRequest;
 import com.xpeho.spring_boot_java_random_user.domain.enums.Gender;
 import com.xpeho.spring_boot_java_random_user.domain.enums.UserSource;
-import com.xpeho.spring_boot_java_random_user.domain.exceptions.InvalidPaginationException;
 import com.xpeho.spring_boot_java_random_user.domain.exceptions.UserNotFoundException;
 import com.xpeho.spring_boot_java_random_user.domain.usecases.*;
 import com.xpeho.spring_boot_java_random_user.presentation.handlers.UserHandler;
@@ -14,8 +13,6 @@ import com.xpeho.spring_boot_java_random_user.presentation.dto.UserResponseDTO;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.CsvSource;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
@@ -81,19 +78,6 @@ class UserHandlerTest {
         assertNull(response.getBody());
         verify(fetchAndSaveRandomUsersUseCase, times(1)).execute(page, size, UserSource.RANDOM_USER);
     }
-
-    @ParameterizedTest
-    @CsvSource({
-            "1, 31",
-            "0, 10",
-            "1, 0"
-    })
-    @DisplayName("Should throw InvalidPaginationException for invalid pagination inputs")
-    void shouldThrowInvalidPaginationExceptionForInvalidPaginationInputs(int page, int size) throws IOException {
-        assertThrows(InvalidPaginationException.class, () -> userHandler.getRandomUsers(page, size, UserSource.DUMMY));
-        verify(fetchAndSaveRandomUsersUseCase, never()).execute(page, size, UserSource.DUMMY);
-    }
-
 
     @Test
     @DisplayName("Should return 200 and user when getUserById succeeds")

--- a/src/test/java/com/xpeho/spring_boot_java_random_user/presentation/exceptions/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/xpeho/spring_boot_java_random_user/presentation/exceptions/GlobalExceptionHandlerTest.java
@@ -3,17 +3,41 @@ package com.xpeho.spring_boot_java_random_user.presentation.exceptions;
 import com.xpeho.spring_boot_java_random_user.domain.exceptions.InvalidPaginationException;
 import com.xpeho.spring_boot_java_random_user.domain.exceptions.UserNotFoundException;
 import com.xpeho.spring_boot_java_random_user.domain.enums.UserSource;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.ConstraintViolationException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
+import java.util.Set;
+
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 class GlobalExceptionHandlerTest {
 
     private final GlobalExceptionHandler handler = new GlobalExceptionHandler();
+
+    @Test
+    @DisplayName("Should return 400 BAD_REQUEST when ConstraintViolationException is thrown")
+    void shouldReturnBadRequestWhenConstraintViolationException() {
+        ConstraintViolation<?> violation = mock(ConstraintViolation.class);
+        when(violation.getPropertyPath()).thenReturn(mock(jakarta.validation.Path.class));
+        when(violation.getPropertyPath().toString()).thenReturn("size");
+        when(violation.getMessage()).thenReturn("must be less than or equal to 30");
+
+        ConstraintViolationException ex = new ConstraintViolationException(Set.of(violation));
+        ResponseEntity<ErrorResponse> response = handler.handleConstraintViolationException(ex);
+
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+        assertNotNull(response.getBody());
+        assertEquals("INVALID_PARAMETER", response.getBody().error());
+        assertEquals(400, response.getBody().status());
+        assertTrue(response.getBody().message().contains("must be less than or equal to 30"));
+    }
 
     @Test
     @DisplayName("Should return 400 BAD_REQUEST when InvalidPaginationException is thrown")

--- a/src/test/java/com/xpeho/spring_boot_java_random_user/presentation/exceptions/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/xpeho/spring_boot_java_random_user/presentation/exceptions/GlobalExceptionHandlerTest.java
@@ -34,7 +34,7 @@ class GlobalExceptionHandlerTest {
 
         assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
         assertNotNull(response.getBody());
-        assertEquals("INVALID_PARAMETER", response.getBody().error());
+        assertEquals("INVALID_PAGINATION", response.getBody().error());
         assertEquals(400, response.getBody().status());
         assertTrue(response.getBody().message().contains("must be less than or equal to 30"));
     }

--- a/src/test/java/feature/StepDefinition.java
+++ b/src/test/java/feature/StepDefinition.java
@@ -78,4 +78,28 @@ public class StepDefinition extends SpringIntegrationTest {
         assertNotNull(createdUserId, "No user was created before this step");
         executeGet("/random-users/" + createdUserId);
     }
+
+    @When("the client call to GET \\/random-users")
+    public void theClientCallToGetRandomUsers() {
+        executeGet("/random-users");
+    }
+
+    @When("the client call to GET \\/random-users with page {int} and size {int}")
+    public void theClientCallToGetRandomUsersWithPageAndSize(int page, int size) {
+        executeGet("/random-users?page=" + page + "&size=" + size);
+    }
+
+    @And("the response contains a list of users")
+    public void theResponseContainsAListOfUsers() throws Exception {
+        JsonNode body = objectMapper.readTree(latestResponse.getBody());
+        assertNotNull(body.get("data"));
+        assertTrue(body.get("data").isArray());
+    }
+
+    @And("the response contains {int} users")
+    public void theResponseContainsUsers(int expectedSize) throws Exception {
+        JsonNode body = objectMapper.readTree(latestResponse.getBody());
+        assertNotNull(body.get("data"));
+        assertEquals(expectedSize, body.get("data").size());
+    }
 }

--- a/src/test/resources/features/get_random_users.feature
+++ b/src/test/resources/features/get_random_users.feature
@@ -1,0 +1,15 @@
+Feature: GET /random-users endpoint
+
+  Scenario: Fetch random users with default parameters
+    When the client call to GET /random-users
+    Then the response status should be 200
+    And the response contains a list of users
+
+  Scenario: Fetch random users with custom page and size
+    When the client call to GET /random-users with page 1 and size 5
+    Then the response status should be 200
+    And the response contains 5 users
+
+  Scenario: Fetch random users with size above maximum
+    When the client call to GET /random-users with page 1 and size 31
+    Then the response status should be 400


### PR DESCRIPTION
## Tests
New Cucumber scenarios: default params, custom page/size, size above max, page/size below min
Assert HTTP status and error code in error responses
Remove unit test for manual pagination validation (no longer applicable without Spring AOP context)
## Exception handling
UserHandler: remove redundant manual page/size checks, rely on @Validated + @Min/@Max from the interface
GlobalExceptionHandler: ConstraintViolationException now returns INVALID_PAGINATION instead of INVALID_PARAMETER to keep a consistent API contract
Logger: pass exception as last argument to preserve stack trace