### PR TITLE
feat(converter): add converter for all tests cucumber

### DIFF
--- a/src/test/java/feature/CucumberTypeConfig.java
+++ b/src/test/java/feature/CucumberTypeConfig.java
@@ -1,0 +1,53 @@
+package feature;
+
+import com.xpeho.spring_boot_java_random_user.domain.entities.UserRequest;
+import io.cucumber.java.DataTableType;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Cucumber converters — transforment automatiquement les données
+ * des fichiers .feature en objets Java typés.
+ */
+public class CucumberTypeConfig {
+
+    /**
+     * Représente une ligne de vérification field/expected dans une DataTable.
+     */
+    public record FieldAssertion(String field, String expected) {}
+
+    /**
+     * Convertit chaque ligne de la DataTable (2 colonnes sans en-tête)
+     * en un objet FieldAssertion.
+     */
+    @DataTableType
+    public FieldAssertion fieldAssertion(List<String> row) {
+        if (row.size() < 2) {
+            throw new IllegalArgumentException(
+                "DataTable row must have at least 2 columns (field | expected), got %d: %s"
+                    .formatted(row.size(), row)
+            );
+        }
+        return new FieldAssertion(row.get(0).trim(), row.get(1).trim());
+    }
+
+    /**
+     * Convertit une ligne de DataTable (Map<String,String>) en UserRequest.
+     * Utilisable dans les .feature avec des tables à en-têtes.
+     */
+    @DataTableType
+    public UserRequest userRequest(Map<String, String> row) {
+        return new UserRequest(
+                row.get("gender"),
+                row.get("firstname"),
+                row.get("lastname"),
+                row.get("civility"),
+                row.get("email"),
+                row.get("phone"),
+                row.get("picture"),
+                row.get("nat")
+        );
+    }
+
+}

--- a/src/test/java/feature/StepDefinition.java
+++ b/src/test/java/feature/StepDefinition.java
@@ -3,7 +3,7 @@ package feature;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.xpeho.spring_boot_java_random_user.domain.entities.UserRequest;
-import io.cucumber.datatable.DataTable;
+import feature.CucumberTypeConfig.FieldAssertion;
 import io.cucumber.java.en.And;
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
@@ -46,26 +46,25 @@ public class StepDefinition extends SpringIntegrationTest {
     }
 
     @And("the user profile")
-    public void theUserProfile(DataTable table) throws Exception{
+    public void theUserProfile(List<FieldAssertion> assertions) throws Exception {
         JsonNode body = objectMapper.readTree(latestResponse.getBody());
-        List<List<String>> rows = table.asLists(String.class);
-        for (List<String> row : rows) {
-            String field = row.get(0).trim();
-            String expected = row.get(1).trim();
-            JsonNode valueNode = body.get(field);
-            assertNotNull(valueNode);
 
-            if ("<generated_id>".equals(expected)) {
-                createdUserId = valueNode.asLong();
-                assertTrue(createdUserId > 0);
-                continue;
+        for (FieldAssertion assertion : assertions) {
+            JsonNode valueNode = body.get(assertion.field());
+            assertNotNull(valueNode, "Field '%s' not found in response".formatted(assertion.field()));
+
+            switch (assertion.expected()) {
+                case "<generated_id>" -> {
+                    createdUserId = valueNode.asLong();
+                    assertTrue(createdUserId > 0);
+                }
+                case "<created_id>" -> {
+                    assertNotNull(createdUserId);
+                    assertEquals(createdUserId.toString(), valueNode.asText());
+                }
+                default -> assertEquals(assertion.expected(), valueNode.asText(),
+                        "Mismatch on field '%s'".formatted(assertion.field()));
             }
-            if ("<created_id>".equals(expected)) {
-                assertNotNull(createdUserId);
-                assertEquals(createdUserId.toString(), valueNode.asText());
-                continue;
-            }
-            assertEquals(expected, valueNode.asText());
         }
     }
 

--- a/src/test/resources/features/get_user.feature
+++ b/src/test/resources/features/get_user.feature
@@ -13,5 +13,5 @@ Feature: Get user endpoint
       | firstname | Emma |
 
   Scenario: Get a user that does not exist
-    When the client call to GET /random-users/999
+    When the client call to GET /random-users/999999
     Then the response status should be 404


### PR DESCRIPTION

# Guide : Utilisation de `@DataTableType` dans les tests Cucumber

## Principe

`@DataTableType` est une annotation Cucumber qui **convertit automatiquement** les lignes d'une DataTable (fichier `.feature`) en objets Java typés. Plus besoin de parser manuellement les `DataTable` dans les steps.

---

## Comment ça marche

```
.feature (données brutes)  →  @DataTableType (conversion)  →  Step (objet typé)
```

1. Cucumber lit la DataTable dans le `.feature`
2. Il cherche un `@DataTableType` dont le **type de retour** correspond au type attendu par le step
3. Il applique le converter **à chaque ligne** et injecte le résultat dans le step

---

## Mise en place

### 1. Créer une classe de converters

Placer un fichier dans le **même package** que les steps (ex : `feature/`). Cucumber le détecte automatiquement.

```java
package feature;

import io.cucumber.java.DataTableType;
import java.util.List;
import java.util.Map;

public class CucumberTypeConfig {
    // Les converters vont ici
}
```

### 2. Choisir le bon type de converter selon le format de la DataTable

#### Format A — Table sans en-tête (liste de paires)

```gherkin
And the user profile
  | id        | <generated_id> |
  | firstname | Emma           |
```

Chaque ligne arrive comme une `List<String>` :

```java
public record FieldAssertion(String field, String expected) {}

@DataTableType
public FieldAssertion fieldAssertion(List<String> row) {
    return new FieldAssertion(row.get(0).trim(), row.get(1).trim());
}
```

Le step reçoit une `List<FieldAssertion>` :

```java
@And("the user profile")
public void theUserProfile(List<FieldAssertion> assertions) {
    // assertions = [FieldAssertion("id", "<generated_id>"), FieldAssertion("firstname", "Emma")]
}
```

#### Format B — Table avec en-têtes (une ou plusieurs lignes d'objets)

```gherkin
Given the following users
  | gender | firstname | lastname | email              |
  | female | Emma      | Stone    | emma@example.com   |
  | male   | John      | Doe      | john@example.com   |
```

Chaque ligne arrive comme un `Map<String, String>` (clé = en-tête) :

```java
@DataTableType
public UserRequest userRequest(Map<String, String> row) {
    return new UserRequest(
        row.get("gender"),
        row.get("firstname"),
        row.get("lastname"),
        row.get("email")
    );
}
```

Le step reçoit une `List<UserRequest>` :

```java
@Given("the following users")
public void theFollowingUsers(List<UserRequest> users) {
    // users = [UserRequest("female", "Emma", ...), UserRequest("male", "John", ...)]
}
```

#### Format C — Table à une seule ligne (objet unique)

Même DataTable avec en-têtes, mais le step attend **un seul objet** :

```java
@Given("a user")
public void aUser(UserRequest user) {
    // Cucumber applique le même @DataTableType et prend la 1ère ligne
}
```

---

## Récapitulatif des signatures

| Format DataTable | Paramètre du `@DataTableType` | Type dans le step |
|---|---|---|
| Sans en-tête, 2 colonnes | `List<String> row` | `List<MonRecord>` |
| Avec en-têtes | `Map<String, String> row` | `List<MonRecord>` ou `MonRecord` |
| Cellule unique | `String cell` | `List<MonType>` |

---

## Bonnes pratiques

- **Un fichier dédié** (`CucumberTypeConfig.java`) pour centraliser tous les converters
- **Utiliser des records** pour les types convertis (immutables, concis)
- **Même package** que les steps — Cucumber scanne le package automatiquement
- **Nommer le converter** comme le type retourné (convention, pas obligation)
- **Ne pas mélanger** logique d'assertion et conversion — le converter ne fait que transformer

---

## Bonus : `@ParameterType`

Pour les paramètres inline (pas les DataTables) :

```gherkin
When the client call to GET /random-users/42
```

```java
@ParameterType("\\d+")
public Long userId(String id) {
    return Long.parseLong(id);
}
```

```java
@When("the client call to GET \\/random-users\\/{userId}")
public void getUser(Long id) { ... }
```

`{userId}` dans l'expression fait le lien avec le nom de la méthode `userId()`.
