### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -6,6 +6,8 @@ on:
     types: [opened, synchronize, reopened]
 
 name: Sonar
+permissions:
+  contents: read
 jobs:
   sonarqube:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/XPEHO/spring_boot_java_random_user/security/code-scanning/2](https://github.com/XPEHO/spring_boot_java_random_user/security/code-scanning/2)

Add an explicit `permissions` block in `.github/workflows/sonar.yaml` at the workflow root level (right after `name:` is the cleanest location).  
For this workflow, the single best minimal non-breaking fix is:

- `contents: read`

This satisfies CodeQL’s requirement and documents least privilege without changing behavior of existing steps.  
If future runs require extra scopes (e.g., PR write access), those can be added later intentionally.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
